### PR TITLE
Add options for minimum/maximum precision on prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A <a href="https://github.com/MichMich/MagicMirror">MagicMirror</a> module used 
 |`headers`| Possibility to show currency change in the last hour, day or week. <br> **Type** One of the following: `change1h, change24h, change7d` <br> **Default** <i>None. All optionals.</i> |
 |`significantDigits`|Total digits to use for rounding the price (including before and after decimal point).<br> **Type** `number` <br> **Default** <i>none</i> |
 |`minimumFractionDigits`|Minimum number of digits after the decimal point in the price.<br> **Type** `number` <br> **Default** <i>2</i> |
-|`maximumFractionDigits`|Maximum number of digits after the decimal point in the price.<br> **Type** `number` <br> **Default** <i>2</i> |
+|`maximumFractionDigits`|Maximum number of digits after the decimal point in the price.<br> **Type** `number` <br> **Default** <i>5</i> |
 |`showGraphs`| Possibility to show currency graph over the last week in `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>false</i> |
 |`coloredLogos`| Toggles white or colored logos `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>false</i> |
 |`fontSize`| Dimension of price text. You can specify pixel values, em values or keywords.<br> **Type:** `string` <br>**Options:** `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large` <br> **Default** <i>xx-large</i> |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ A <a href="https://github.com/MichMich/MagicMirror">MagicMirror</a> module used 
 |`displayType`| Sets the display of the module. <br>**Type:** `string`<br>**Options:** `detail, logo, logoWithChanges`<br/>**Default:** <i>detail</i>
 |`logoHeaderText`| Defines the headline text if `displayType: logo` is set.<br/>**Type:** `string`<br>**Default:** <i>Crypto currency</i>
 |`headers`| Possibility to show currency change in the last hour, day or week. <br> **Type** One of the following: `change1h, change24h, change7d` <br> **Default** <i>None. All optionals.</i> |
-|`significantDigits`|Total digits to use for rounding the price (including before and after decimal point).<br> **Type** `number` <br> **Default** <i>2</i> |
+|`significantDigits`|Total digits to use for rounding the price (including before and after decimal point).<br> **Type** `number` <br> **Default** <i>none</i> |
+|`minimumFractionDigits`|Minimum number of digits after the decimal point in the price.<br> **Type** `number` <br> **Default** <i>2</i> |
+|`maximumFractionDigits`|Maximum number of digits after the decimal point in the price.<br> **Type** `number` <br> **Default** <i>2</i> |
 |`showGraphs`| Possibility to show currency graph over the last week in `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>false</i> |
 |`coloredLogos`| Toggles white or colored logos `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>false</i> |
 |`fontSize`| Dimension of price text. You can specify pixel values, em values or keywords.<br> **Type:** `string` <br>**Options:** `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large` <br> **Default** <i>xx-large</i> |
@@ -101,6 +103,7 @@ It's my first module here after that I built a MagicMirror. I'm so proud of it a
 ## Contributors
 <a href="https://github.com/Klizzy/MMM-cryptocurrency">Klizzy</a> for translations and multiple currencies.
 <a href="https://github.com/olexs/MMM-cryptocurrency">olexs</a> for currencies graphs and significant digits.
+<a href="https://github.com/mattdy/MMM-cryptocurrency">mattdy</a> for minimum/maximum fraction length on pricing
 
 
 The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ It's my first module here after that I built a MagicMirror. I'm so proud of it a
 <br>Leave me some feedback in the forum. Thank you!
 
 ## Contributors
-<a href="https://github.com/Klizzy/MMM-cryptocurrency">Klizzy</a> for translations and multiple currencies.
-<a href="https://github.com/olexs/MMM-cryptocurrency">olexs</a> for currencies graphs and significant digits.
-<a href="https://github.com/mattdy/MMM-cryptocurrency">mattdy</a> for minimum/maximum fraction length on pricing
+- <a href="https://github.com/Klizzy/MMM-cryptocurrency">Klizzy</a> for translations and multiple currencies.
+- <a href="https://github.com/olexs/MMM-cryptocurrency">olexs</a> for currencies graphs and significant digits.
+- <a href="https://github.com/mattdy/MMM-cryptocurrency">mattdy</a> for minimum/maximum fraction length on pricing
 
 
 The MIT License (MIT)


### PR DESCRIPTION
I found the `significantDigits` setting a bit too much of a blunt instrument, so added options to specify a minimum and maximum number of digits after the decimal point in the price - these are `minimumFractionDigits` and `maximumFractionDigits` in fitting with the `.toLocaleString` naming convention. As with `significantDigits`, this can also be set on a per-currency basis using an array.

I hope this should fix #42, and should make the default configuration slightly more sensible, without losing too much precision on high-value coins while losing it on low-value coins.

I've also updated the README appropriately to match.