### PR TITLE
Replacing Request with node-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ A <a href="https://github.com/MichMich/MagicMirror">MagicMirror</a> module used 
 
 ## Installation
 1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/matteodanelli/MMM-cryptocurrency.git`.
-2. Add the module inside `config.js` placing it where you prefer ;)
+2. While inside the MMM-cryptocurrency folder, Execute `npm install` to install the dependencies.
+3. Add the module inside `config.js` placing it where you prefer ;)
 
 
 ## Config

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,5 +1,5 @@
 var NodeHelper = require('node_helper')
-var request = require('request')
+const fetch = require('node-fetch');
 
 module.exports = NodeHelper.create({
   start: function () {
@@ -14,11 +14,13 @@ module.exports = NodeHelper.create({
 
   getTickers: function (url) {
     var self = this
-    request({url: url, method: 'GET'}, function (error, response, body) {
-      if (!error && response.statusCode == 200) {
-        self.sendSocketNotification('got_result', JSON.parse(body))
-      }
+    fetch(url)
+      .then(res => res.text())
+      .then(body => {
+        var result = JSON.parse(body)
+        self.sendSocketNotification('got_result', result)
+
     })
-  }
+  }  
 
 })

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "Magic-Mirror-Cryptocurrency",
+    "version": "1.0.0",
+    "dependencies": {
+      "node-fetch": "^2.6.1"
+    },
+    "description": "A <a href=\"https://github.com/MichMich/MagicMirror\">MagicMirror</a> module used to get real-time values of crypto currencies.",
+    "main": "MMM-cryptocurrency.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/matteodanelli/MMM-cryptocurrency.git"
+    },
+    "author": "matteo danelli",
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/matteodanelli/MMM-cryptocurrency/issues"
+    },
+    "homepage": "https://github.com/matteodanelli/MMM-cryptocurrency#readme"
+  }
+  


### PR DESCRIPTION
Request was removed from Magic mirror since Request has been depreciated. node-fetch is a replacement to do the GET request and pass the json back to the results. Also added a package.json with the node-fetch dependency to make sure the clients pull it down and have it. new Steps included in the read-me. (PS: first public PR to a project, feed back is appreciated 👍  )