### PR TITLE
Change API endpoint to get just config currencies

### DIFF
--- a/MMM-cryptocurrency.js
+++ b/MMM-cryptocurrency.js
@@ -144,7 +144,8 @@ Module.register('MMM-cryptocurrency', {
 
     getTicker: function() {
         var conversion = this.config.conversion;
-        var url = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?start=1&limit=' + this.config.limit + '&convert=' + conversion + '&CMC_PRO_API_KEY=' + this.config.apikey;
+        var slugs = this.config.currency.join(',');
+        var url = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?slug=' + slugs + '&convert=' + conversion + '&CMC_PRO_API_KEY=' + this.config.apikey;
         this.sendSocketNotification('get_ticker', url);
     },
 
@@ -247,17 +248,11 @@ Module.register('MMM-cryptocurrency', {
      */
     getWantedCurrencies: function(chosenCurrencies, apiResult) {
         var filteredCurrencies = []
-        for (var i = 0; i < chosenCurrencies.length; i++) {
-            for (var j = 0; j < apiResult.data.length; j++) {
-                var userCurrency = chosenCurrencies[i]
-
-                var remoteCurrency = apiResult['data'][j]
-                if (userCurrency == remoteCurrency.slug) {
-                    remoteCurrency = this.formatPrice(remoteCurrency)
-                    remoteCurrency = this.formatPercentage(remoteCurrency)
-                    filteredCurrencies.push(remoteCurrency)
-                }
-            }
+        for (var symbol in apiResult.data) {
+            var remoteCurrency = apiResult.data[symbol]
+            remoteCurrency = this.formatPrice(remoteCurrency)
+            remoteCurrency = this.formatPercentage(remoteCurrency)
+            filteredCurrencies.push(remoteCurrency)
         }
         return filteredCurrencies
     },

--- a/MMM-cryptocurrency.js
+++ b/MMM-cryptocurrency.js
@@ -13,7 +13,6 @@ Module.register('MMM-cryptocurrency', {
         maximumFractionDigits: 5,
         coloredLogos: true,
         fontSize: 'xx-large',
-        limit: '100',
         apiDelay: 300000,
     },
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A <a href="https://github.com/MichMich/MagicMirror">MagicMirror</a> module used 
 |`showGraphs`| Possibility to show currency graph over the last week in `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>false</i> |
 |`coloredLogos`| Toggles white or colored logos `displayType: logo`. <br> **Type:** `boolean` <br> **Default** <i>true</i> |
 |`fontSize`| Dimension of price text. You can specify pixel values, em values or keywords.<br> **Type:** `string` <br>**Options:** `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large` <br> **Default** <i>xx-large</i> |
-|`limit`| Number of currencies to download, according to CoinMarketCap ranking. Increase this value only if you cannot display a currency. <br> **Type:** `string` <br> **Default** <i>100</i> |
 
 Here is an example of an entry in `config.js`
 ```


### PR DESCRIPTION
As one on my favorite cryptocurrencies has shifted out of the top 100, then out of the top 200, I decided to update the code to use another endpoint (https://coinmarketcap.com/api/documentation/v1/#operation/getV1CryptocurrencyQuotesLatest) to get just the currencies I care about without getting others I don't need.