### PR TITLE
Use .svg sparklines instead of .png (fix sparklines not updating anymore)

### DIFF
--- a/MMM-cryptocurrency.js
+++ b/MMM-cryptocurrency.js
@@ -500,7 +500,7 @@ Module.register("MMM-cryptocurrency", {
           graph.src =
             "https://s3.coinmarketcap.com/generated/sparklines/web/7d/usd/" +
             this.sparklineIds[apiResult[j].slug] +
-            ".png?cachePrevention=" +
+            ".svg?cachePrevention=" +
             Math.random();
           graphWrapper.appendChild(graph);
         }


### PR DESCRIPTION
.png sparklines seem to have stopped updating. Coinmarketcap website uses .svg images instead, no reason not to do the same in the module, and they are up to date.